### PR TITLE
Set up preview environment for changes

### DIFF
--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -1,0 +1,47 @@
+name: Cleanup PR Preview
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [ main ]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  cleanup-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout gh-pages
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          token: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Remove preview directory
+        run: |
+          if [ -d "preview" ]; then
+            rm -rf preview
+            git config user.name github-actions
+            git config user.email github-actions@github.com
+            git add .
+            git commit -m "Remove preview for closed PR #${{ github.event.number }}" || exit 0
+            git push origin gh-pages
+          else
+            echo "Preview directory not found, nothing to clean up"
+          fi
+      
+      - name: Comment on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { repo, owner } = context.repo;
+            const pr_number = context.issue.number;
+            
+            github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: pr_number,
+              body: `🧹 **Preview cleaned up!**\n\nThe preview deployment has been removed since this PR was closed.`
+            });

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,118 @@
+name: Deploy PR Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [ main ]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+  pull-requests: write
+
+concurrency:
+  group: "preview-${{ github.event.number }}"
+  cancel-in-progress: true
+
+jobs:
+  build-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: 'npm'
+      
+      - name: Install dependencies
+        run: npm ci
+      
+      - name: Optimize images
+        run: node scripts/optimize-images.js
+      
+      - name: Build with Next.js for Preview
+        run: npm run build:preview
+        env:
+          NEXT_PUBLIC_BASE_PATH: /preview
+      
+      - name: Create preview directory structure
+        run: |
+          mkdir -p preview-site/preview
+          cp -r ./out/* ./preview-site/preview/
+      
+      - name: Upload preview artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: preview-site-${{ github.event.number }}
+          path: ./preview-site
+          retention-days: 7
+
+  deploy-preview:
+    runs-on: ubuntu-latest
+    needs: build-preview
+    steps:
+      - name: Checkout gh-pages
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: gh-pages
+          token: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Download preview artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: preview-site-${{ github.event.number }}
+          path: ./preview-build
+      
+      - name: Setup preview directory
+        run: |
+          cd gh-pages
+          # Pull latest changes to avoid conflicts
+          git pull origin gh-pages
+          rm -rf preview
+          cp -r ../preview-build/preview ./
+          
+      - name: Deploy to gh-pages
+        run: |
+          cd gh-pages
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          
+          # Check if there are changes to commit
+          if git diff --quiet && git diff --staged --quiet; then
+            echo "No changes to commit"
+            exit 0
+          fi
+          
+          git add preview
+          git commit -m "Deploy preview for PR #${{ github.event.number }}"
+          
+          # Retry push in case of conflicts
+          for i in {1..3}; do
+            git push origin gh-pages && break
+            echo "Push failed, retrying in 5 seconds..."
+            sleep 5
+            git pull --rebase origin gh-pages
+          done
+      
+      - name: Comment on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { repo, owner } = context.repo;
+            const pr_number = context.issue.number;
+            const baseUrl = `https://${owner}.github.io/${repo}`;
+            const previewUrl = `${baseUrl}/preview/`;
+            
+            github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: pr_number,
+              body: `🚀 **Preview deployed!**\n\nYou can preview your changes at: ${previewUrl}\n\n*This preview will be updated automatically when you push new commits to this PR.*`
+            });

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'export',
+  trailingSlash: true,
+  basePath: process.env.NEXT_PUBLIC_BASE_PATH || '',
+  assetPrefix: process.env.NEXT_PUBLIC_BASE_PATH || '',
   images: {
     unoptimized: true,
     deviceSizes: [640, 750, 828, 1080, 1200, 1920, 2048],

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "build:preview": "NEXT_PUBLIC_BASE_PATH=/preview next build",
     "start": "next start",
     "lint": "next lint",
     "optimize-images": "node scripts/optimize-images.js",


### PR DESCRIPTION
Enable preview deployments for GitHub Pages, allowing PR changes to be viewed at a `/preview/` path.