### PR TITLE
Verify GitHub Pages deployment with actions

### DIFF
--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -13,16 +13,6 @@ jobs:
   cleanup-preview:
     runs-on: ubuntu-latest
     steps:
-      - name: Install Surge CLI
-        run: npm install -g surge
-        
-      - name: Remove Surge deployment
-        run: |
-          surge teardown pr-${{ github.event.number }}-${{ github.repository_owner }}-${{ github.event.repository.name }}.surge.sh --token ${{ secrets.SURGE_TOKEN }}
-        env:
-          SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
-        continue-on-error: true
-      
       - name: Comment on PR
         uses: actions/github-script@v7
         with:
@@ -54,5 +44,5 @@ jobs:
               owner,
               repo,
               issue_number: pr_number,
-              body: `🧹 **Preview cleaned up!**\n\nThe preview deployment has been removed from Surge.sh since this PR was closed.`
+              body: `🧹 **Preview cleaned up!**\n\nThe preview deployment will be automatically removed by Firebase Hosting in 30 days, or you can manually delete the preview channel from the Firebase Console if needed.`
             });

--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -13,6 +13,16 @@ jobs:
   cleanup-preview:
     runs-on: ubuntu-latest
     steps:
+      - name: Install Surge CLI
+        run: npm install -g surge
+        
+      - name: Remove Surge deployment
+        run: |
+          surge teardown pr-${{ github.event.number }}-${{ github.repository_owner }}-${{ github.event.repository.name }}.surge.sh --token ${{ secrets.SURGE_TOKEN }}
+        env:
+          SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
+        continue-on-error: true
+      
       - name: Comment on PR
         uses: actions/github-script@v7
         with:
@@ -44,5 +54,5 @@ jobs:
               owner,
               repo,
               issue_number: pr_number,
-              body: `🧹 **Preview cleaned up!**\n\nThe preview deployment has been automatically cleaned up by Netlify since this PR was closed.`
+              body: `🧹 **Preview cleaned up!**\n\nThe preview deployment has been removed from Surge.sh since this PR was closed.`
             });

--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -13,16 +13,6 @@ jobs:
   cleanup-preview:
     runs-on: ubuntu-latest
     steps:
-      - name: Install Surge CLI
-        run: npm install -g surge
-        
-      - name: Remove Surge deployment
-        run: |
-          surge teardown pr-${{ github.event.number }}-${{ github.repository_owner }}-${{ github.event.repository.name }}.surge.sh --token ${{ secrets.SURGE_TOKEN }}
-        env:
-          SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
-        continue-on-error: true
-      
       - name: Comment on PR
         uses: actions/github-script@v7
         with:
@@ -54,5 +44,5 @@ jobs:
               owner,
               repo,
               issue_number: pr_number,
-              body: `🧹 **Preview cleaned up!**\n\nThe preview deployment has been removed from Surge.sh since this PR was closed.`
+              body: `🧹 **Preview cleaned up!**\n\nThe preview deployment has been automatically cleaned up by Netlify since this PR was closed.`
             });

--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -6,31 +6,22 @@ on:
     branches: [ main ]
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
 
 jobs:
   cleanup-preview:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout gh-pages
-        uses: actions/checkout@v4
-        with:
-          ref: gh-pages
-          token: ${{ secrets.GITHUB_TOKEN }}
-      
-      - name: Remove preview directory
+      - name: Install Surge CLI
+        run: npm install -g surge
+        
+      - name: Remove Surge deployment
         run: |
-          if [ -d "preview" ]; then
-            rm -rf preview
-            git config user.name github-actions
-            git config user.email github-actions@github.com
-            git add .
-            git commit -m "Remove preview for closed PR #${{ github.event.number }}" || exit 0
-            git push origin gh-pages
-          else
-            echo "Preview directory not found, nothing to clean up"
-          fi
+          surge teardown pr-${{ github.event.number }}-${{ github.repository_owner }}-${{ github.event.repository.name }}.surge.sh --token ${{ secrets.SURGE_TOKEN }}
+        env:
+          SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
+        continue-on-error: true
       
       - name: Comment on PR
         uses: actions/github-script@v7
@@ -39,9 +30,29 @@ jobs:
             const { repo, owner } = context.repo;
             const pr_number = context.issue.number;
             
+            // Delete previous preview comments
+            const comments = await github.rest.issues.listComments({
+              owner,
+              repo,
+              issue_number: pr_number,
+            });
+            
+            for (const comment of comments.data) {
+              if (comment.user.login === 'github-actions[bot]' && 
+                  (comment.body.includes('🚀 **Preview deployed!**') || 
+                   comment.body.includes('🧹 **Preview cleaned up!**'))) {
+                await github.rest.issues.deleteComment({
+                  owner,
+                  repo,
+                  comment_id: comment.id,
+                });
+              }
+            }
+            
+            // Create cleanup comment
             github.rest.issues.createComment({
               owner,
               repo,
               issue_number: pr_number,
-              body: `🧹 **Preview cleaned up!**\n\nThe preview deployment has been removed since this PR was closed.`
+              body: `🧹 **Preview cleaned up!**\n\nThe preview deployment has been removed from Surge.sh since this PR was closed.`
             });

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -39,22 +39,22 @@ jobs:
         env:
           NEXT_PUBLIC_BASE_PATH: ""
       
-      - name: Install Surge CLI
-        run: npm install -g surge
-      
-      - name: Deploy to Surge
-        run: |
-          surge ./out --domain pr-${{ github.event.number }}-${{ github.repository_owner }}-${{ github.event.repository.name }}.surge.sh --token ${{ secrets.SURGE_TOKEN }}
-        env:
-          SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
-      
+      - name: Deploy to Firebase Hosting
+        uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          repoToken: '${{ secrets.GITHUB_TOKEN }}'
+          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}'
+          projectId: '${{ secrets.FIREBASE_PROJECT_ID }}'
+          channelId: 'pr-${{ github.event.number }}'
+          expires: 30d
+          
       - name: Comment on PR
         uses: actions/github-script@v7
         with:
           script: |
             const { repo, owner } = context.repo;
             const pr_number = context.issue.number;
-            const previewUrl = `https://pr-${pr_number}-${owner}-${repo}.surge.sh`;
+            const previewUrl = `https://${{ secrets.FIREBASE_PROJECT_ID }}--pr-${pr_number}.web.app`;
             
             // Delete previous comments from this action
             const comments = await github.rest.issues.listComments({
@@ -78,5 +78,5 @@ jobs:
               owner,
               repo,
               issue_number: pr_number,
-              body: `🚀 **Preview deployed!**\n\nYou can preview your changes at: ${previewUrl}\n\n*This preview will be updated automatically when you push new commits to this PR.*\n\n**Note:** Preview is hosted on Surge.sh using GitHub Actions deployment method.`
+              body: `🚀 **Preview deployed!**\n\nYou can preview your changes at: ${previewUrl}\n\n*This preview will be updated automatically when you push new commits to this PR.*\n\n**Note:** Preview is hosted on Firebase Hosting using GitHub Actions deployment method.`
             });

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -39,17 +39,14 @@ jobs:
         env:
           NEXT_PUBLIC_BASE_PATH: ""
       
-      - name: Deploy to Netlify
-        uses: nwtgck/actions-netlify@v3.0
-        with:
-          publish-dir: './out'
-          production-branch: main
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          deploy-message: "Deploy from GitHub Actions - PR #${{ github.event.number }}"
-          alias: pr-${{ github.event.number }}
+      - name: Install Surge CLI
+        run: npm install -g surge
+      
+      - name: Deploy to Surge
+        run: |
+          surge ./out --domain pr-${{ github.event.number }}-${{ github.repository_owner }}-${{ github.event.repository.name }}.surge.sh --token ${{ secrets.SURGE_TOKEN }}
         env:
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+          SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
       
       - name: Comment on PR
         uses: actions/github-script@v7
@@ -57,7 +54,7 @@ jobs:
           script: |
             const { repo, owner } = context.repo;
             const pr_number = context.issue.number;
-            const previewUrl = `https://pr-${pr_number}--${{ secrets.NETLIFY_SITE_NAME }}.netlify.app`;
+            const previewUrl = `https://pr-${pr_number}-${owner}-${repo}.surge.sh`;
             
             // Delete previous comments from this action
             const comments = await github.rest.issues.listComments({
@@ -81,5 +78,5 @@ jobs:
               owner,
               repo,
               issue_number: pr_number,
-              body: `🚀 **Preview deployed!**\n\nYou can preview your changes at: ${previewUrl}\n\n*This preview will be updated automatically when you push new commits to this PR.*\n\n**Note:** Preview is now hosted on Netlify using GitHub Actions deployment method.`
+              body: `🚀 **Preview deployed!**\n\nYou can preview your changes at: ${previewUrl}\n\n*This preview will be updated automatically when you push new commits to this PR.*\n\n**Note:** Preview is hosted on Surge.sh using GitHub Actions deployment method.`
             });

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -7,8 +7,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
   pull-requests: write
 
 concurrency:
@@ -16,10 +14,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-preview:
+  build-and-deploy-preview:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout PR
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
@@ -36,86 +34,19 @@ jobs:
       - name: Optimize images
         run: node scripts/optimize-images.js
       
-      - name: Build with Next.js for Preview
+      - name: Build PR preview
         run: npm run build:preview
         env:
-          NEXT_PUBLIC_BASE_PATH: /preview
+          NEXT_PUBLIC_BASE_PATH: ""
       
-      - name: Create preview directory structure
+      - name: Install Surge CLI
+        run: npm install -g surge
+      
+      - name: Deploy to Surge
         run: |
-          mkdir -p preview-site/preview
-          cp -r ./out/* ./preview-site/preview/
-      
-      - name: Upload preview artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: preview-site-${{ github.event.number }}
-          path: ./preview-site
-          retention-days: 7
-
-  deploy-preview:
-    runs-on: ubuntu-latest
-    needs: build-preview
-    steps:
-      - name: Checkout gh-pages
-        uses: actions/checkout@v4
-        with:
-          ref: gh-pages
-          path: gh-pages
-          token: ${{ secrets.GITHUB_TOKEN }}
-        continue-on-error: true
-      
-      - name: Create gh-pages branch if it doesn't exist
-        run: |
-          if [ ! -d "gh-pages" ]; then
-            git checkout --orphan gh-pages
-            git rm -rf .
-            echo "# GitHub Pages" > README.md
-            git add README.md
-            git config user.name github-actions
-            git config user.email github-actions@github.com
-            git commit -m "Initialize gh-pages branch"
-            git push origin gh-pages
-            cd ..
-            git clone --branch gh-pages https://github.com/${{ github.repository }}.git gh-pages
-          fi
-      
-      - name: Download preview artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: preview-site-${{ github.event.number }}
-          path: ./preview-build
-      
-      - name: Setup preview directory
-        run: |
-          cd gh-pages
-          # Pull latest changes to avoid conflicts
-          git pull origin gh-pages || true
-          rm -rf preview
-          cp -r ../preview-build/preview ./
-          
-      - name: Deploy to gh-pages
-        run: |
-          cd gh-pages
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-          
-          # Check if there are changes to commit
-          if git diff --quiet && git diff --staged --quiet; then
-            echo "No changes to commit"
-            exit 0
-          fi
-          
-          git add preview
-          git commit -m "Deploy preview for PR #${{ github.event.number }}"
-          
-          # Retry push in case of conflicts
-          for i in {1..3}; do
-            git push origin gh-pages && break
-            echo "Push failed, retrying in 5 seconds..."
-            sleep 5
-            git pull --rebase origin gh-pages
-          done
+          surge ./out --domain pr-${{ github.event.number }}-${{ github.repository_owner }}-${{ github.event.repository.name }}.surge.sh --token ${{ secrets.SURGE_TOKEN }}
+        env:
+          SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
       
       - name: Comment on PR
         uses: actions/github-script@v7
@@ -123,12 +54,29 @@ jobs:
           script: |
             const { repo, owner } = context.repo;
             const pr_number = context.issue.number;
-            const baseUrl = `https://${owner}.github.io/${repo}`;
-            const previewUrl = `${baseUrl}/preview/`;
+            const previewUrl = `https://pr-${pr_number}-${owner}-${repo}.surge.sh`;
             
+            // Delete previous comments from this action
+            const comments = await github.rest.issues.listComments({
+              owner,
+              repo,
+              issue_number: pr_number,
+            });
+            
+            for (const comment of comments.data) {
+              if (comment.user.login === 'github-actions[bot]' && comment.body.includes('🚀 **Preview deployed!**')) {
+                await github.rest.issues.deleteComment({
+                  owner,
+                  repo,
+                  comment_id: comment.id,
+                });
+              }
+            }
+            
+            // Create new comment
             github.rest.issues.createComment({
               owner,
               repo,
               issue_number: pr_number,
-              body: `🚀 **Preview deployed!**\n\nYou can preview your changes at: ${previewUrl}\n\n*This preview will be updated automatically when you push new commits to this PR.*`
+              body: `🚀 **Preview deployed!**\n\nYou can preview your changes at: ${previewUrl}\n\n*This preview will be updated automatically when you push new commits to this PR.*\n\n**Note:** Preview is now hosted on Surge.sh using GitHub Actions deployment method.`
             });

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -39,14 +39,17 @@ jobs:
         env:
           NEXT_PUBLIC_BASE_PATH: ""
       
-      - name: Install Surge CLI
-        run: npm install -g surge
-      
-      - name: Deploy to Surge
-        run: |
-          surge ./out --domain pr-${{ github.event.number }}-${{ github.repository_owner }}-${{ github.event.repository.name }}.surge.sh --token ${{ secrets.SURGE_TOKEN }}
+      - name: Deploy to Netlify
+        uses: nwtgck/actions-netlify@v3.0
+        with:
+          publish-dir: './out'
+          production-branch: main
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          deploy-message: "Deploy from GitHub Actions - PR #${{ github.event.number }}"
+          alias: pr-${{ github.event.number }}
         env:
-          SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
       
       - name: Comment on PR
         uses: actions/github-script@v7
@@ -54,7 +57,7 @@ jobs:
           script: |
             const { repo, owner } = context.repo;
             const pr_number = context.issue.number;
-            const previewUrl = `https://pr-${pr_number}-${owner}-${repo}.surge.sh`;
+            const previewUrl = `https://pr-${pr_number}--${{ secrets.NETLIFY_SITE_NAME }}.netlify.app`;
             
             // Delete previous comments from this action
             const comments = await github.rest.issues.listComments({
@@ -78,5 +81,5 @@ jobs:
               owner,
               repo,
               issue_number: pr_number,
-              body: `🚀 **Preview deployed!**\n\nYou can preview your changes at: ${previewUrl}\n\n*This preview will be updated automatically when you push new commits to this PR.*\n\n**Note:** Preview is now hosted on Surge.sh using GitHub Actions deployment method.`
+              body: `🚀 **Preview deployed!**\n\nYou can preview your changes at: ${previewUrl}\n\n*This preview will be updated automatically when you push new commits to this PR.*\n\n**Note:** Preview is now hosted on Netlify using GitHub Actions deployment method.`
             });

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,27 @@
+{
+  "hosting": {
+    "public": "out",
+    "ignore": [
+      "firebase.json",
+      "**/.*",
+      "**/node_modules/**"
+    ],
+    "rewrites": [
+      {
+        "source": "**",
+        "destination": "/index.html"
+      }
+    ],
+    "headers": [
+      {
+        "source": "**/*.@(js|css)",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "max-age=31536000"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/github-actions-deployment-setup.md
+++ b/github-actions-deployment-setup.md
@@ -13,7 +13,7 @@ Your GitHub Actions workflows have been **fully migrated to the GitHub Actions d
 - Uses `github-pages` environment
 
 ### 2. Updated PR Preview Deployment (`preview.yml`) ✅
-**Migrated from gh-pages branch to GitHub Actions + modern hosting:**
+**Migrated from gh-pages branch to GitHub Actions + Firebase Hosting:**
 
 **Previous Issues:**
 - Used gh-pages branch checkout and manipulation
@@ -22,89 +22,44 @@ Your GitHub Actions workflows have been **fully migrated to the GitHub Actions d
 
 **New Solution:**
 - **Uses GitHub Actions** for build and deployment process
-- **Multiple hosting options available** for isolated PR previews
+- **Deploys to Firebase Hosting** using preview channels for isolated PR previews
 - **Eliminates gh-pages branch usage** completely
 - Uses only `contents: read` and `pull-requests: write` permissions
-- Each PR gets its own URL
+- Each PR gets its own URL: `https://{project-id}--pr-{number}.web.app`
 
 ### 3. Updated Cleanup (`cleanup-preview.yml`) ✅
-**Migrated from gh-pages branch to modern hosting management:**
-- Removes deployments using hosting service APIs
+**Migrated from gh-pages branch to Firebase auto-expiration:**
+- Firebase preview channels automatically expire after 30 days
+- No manual cleanup needed - Firebase handles it automatically
 - Uses minimal permissions
 - No longer requires `contents: write` permission
 
-## PR Preview Hosting Options
+## Required Setup - Firebase Hosting
 
-Choose one of these excellent alternatives:
+### **Step 1: Create Firebase Project**
+1. Go to [Firebase Console](https://console.firebase.google.com/)
+2. Click **"Create a project"** or **"Add project"**
+3. Enter your project name (e.g., `your-app-preview`)
+4. Optionally enable Google Analytics
+5. Click **"Create project"**
 
-### **Option 1: Netlify** 🌟 **Most Popular**
-- **Pros:** Excellent GitHub integration, generous free tier, form handling, edge functions
-- **Cons:** Can get expensive with high traffic
-- **URL Pattern:** `https://pr-{number}--{site-name}.netlify.app`
+### **Step 2: Enable Firebase Hosting**
+1. In your Firebase project dashboard, click **"Hosting"** in the left sidebar
+2. Click **"Get started"**
+3. Follow the setup wizard (you can skip the Firebase CLI installation for now)
 
-**Required Secrets:**
-- `NETLIFY_AUTH_TOKEN` - Personal access token from Netlify
-- `NETLIFY_SITE_ID` - Site ID from Netlify dashboard
-- `NETLIFY_SITE_NAME` - Your Netlify site name
+### **Step 3: Create Service Account**
+1. Go to **Project Settings** (gear icon) → **Service accounts**
+2. Click **"Generate new private key"**
+3. Save the JSON file securely - you'll need this for GitHub secrets
 
-**Setup:**
-1. Create Netlify account and site
-2. Generate personal access token
-3. Add secrets to GitHub repository
+### **Step 4: Add GitHub Secrets**
+Go to your GitHub repository **Settings > Secrets and variables > Actions** and add:
 
-### **Option 2: Vercel** 🌟 **Best for Next.js**
-- **Pros:** Excellent Next.js optimization, edge functions, great DX
-- **Cons:** Pricing can add up, more complex for non-Next.js projects
-- **URL Pattern:** `https://pr-{number}-{repo}.vercel.app`
+- **`FIREBASE_SERVICE_ACCOUNT`**: Paste the entire contents of the JSON file from Step 3
+- **`FIREBASE_PROJECT_ID`**: Your Firebase project ID (found in Firebase Console project settings)
 
-**Required Secrets:**
-- `VERCEL_TOKEN` - Vercel API token
-- `VERCEL_ORG_ID` - Organization ID from Vercel
-- `VERCEL_PROJECT_ID` - Project ID from Vercel
-
-**Setup:**
-1. Create Vercel account and project
-2. Get API token and IDs from Vercel dashboard
-3. Add secrets to GitHub repository
-
-### **Option 3: Firebase Hosting** 🌟 **Google's Solution**
-- **Pros:** Great performance, tight Google Cloud integration, preview channels
-- **Cons:** Requires Google account, more complex setup
-- **URL Pattern:** `https://{project-id}--pr-{number}.web.app`
-
-**Required Secrets:**
-- `FIREBASE_SERVICE_ACCOUNT` - Service account JSON
-- `FIREBASE_PROJECT_ID` - Firebase project ID
-
-**Setup:**
-1. Create Firebase project
-2. Enable Hosting
-3. Create service account with Hosting Admin role
-4. Add secrets to GitHub repository
-
-### **Option 4: Cloudflare Pages** 🌟 **Fast & Global**
-- **Pros:** Excellent performance, global CDN, generous free tier
-- **Cons:** Less mature ecosystem than others
-- **URL Pattern:** `https://pr-{number}.{project}.pages.dev`
-
-**Required Secrets:**
-- `CLOUDFLARE_API_TOKEN` - API token with Pages permissions
-- `CLOUDFLARE_ACCOUNT_ID` - Account ID from Cloudflare
-- `CLOUDFLARE_PROJECT_NAME` - Pages project name
-
-**Setup:**
-1. Create Cloudflare account
-2. Create Pages project
-3. Generate API token with Pages permissions
-4. Add secrets to GitHub repository
-
-### **Option 5: Surge.sh** (Current) 💡 **Simple & Free**
-- **Pros:** Simple setup, completely free, great for small projects
-- **Cons:** Basic features, limited customization
-- **URL Pattern:** `https://pr-{number}-{owner}-{repo}.surge.sh`
-
-## Required GitHub Pages Setup (Production)
-
+### **Step 5: Required GitHub Pages Setup (Production)**
 1. Go to **Settings > Pages** in your GitHub repository
 2. Set **Source** to: **GitHub Actions**
 3. No branch selection needed
@@ -118,9 +73,9 @@ Choose one of these excellent alternatives:
 
 ### PR Preview Deployments:
 1. **Build:** Uses GitHub Actions to build PR code
-2. **Deploy:** Uses GitHub Actions to deploy to chosen hosting service
-3. **Result:** Each PR gets unique URL based on chosen service
-4. **Cleanup:** Automatically removes deployment when PR closes
+2. **Deploy:** Uses GitHub Actions to deploy to Firebase Hosting preview channel
+3. **Result:** Each PR gets unique URL: `https://{project-id}--pr-{number}.web.app`
+4. **Cleanup:** Automatically expires after 30 days
 
 ## Benefits of This Setup
 
@@ -128,46 +83,45 @@ Choose one of these excellent alternatives:
 - ✅ **Consistent deployment approach** - GitHub Actions for everything
 - ✅ **Better security** - Minimal permissions throughout
 - ✅ **Isolated PR previews** - Each PR gets its own domain
-- ✅ **Automatic cleanup** - Deployments removed when PRs close
+- ✅ **Automatic cleanup** - Firebase handles expiration automatically
 - ✅ **No conflicts** - PR previews don't interfere with production site
-- ✅ **Industry standard** - All options are widely used for PR previews
-- ✅ **Choice** - Pick the hosting service that fits your needs and budget
+- ✅ **Industry standard** - Firebase Hosting is widely used and reliable
+- ✅ **Great performance** - Firebase's global CDN ensures fast loading
 
-## Switching Between Options
+## Why Firebase Hosting for PR Previews?
 
-To switch between hosting options:
-1. **Replace** your `preview.yml` with the desired option's workflow
-2. **Update** GitHub secrets with the new service's requirements  
-3. **Update** cleanup workflow if needed
-4. **Test** with a new PR
-
-Example workflows are provided as `.example` files in your `.github/workflows/` directory.
-
-## Why These Alternatives?
-
-GitHub Pages with GitHub Actions method is designed for single-site deployment. Using these hosting services for PR previews allows us to:
-- Maintain GitHub Actions consistency
-- Avoid overwriting the production site
-- Provide isolated preview environments
-- Use services designed for temporary/preview deployments
+Firebase Hosting with preview channels is specifically designed for this use case:
+- **Preview channels** - Built for temporary preview deployments
+- **Automatic expiration** - No manual cleanup needed
+- **GitHub integration** - Official Firebase GitHub Action
+- **Performance** - Global CDN and optimized delivery
+- **Reliability** - Google's infrastructure
 
 ## URLs
 
 - **Production:** Your GitHub Pages URL (e.g., `https://username.github.io/repo`)
-- **PR Previews:** Varies by chosen hosting service (see options above)
+- **PR Previews:** `https://{firebase-project-id}--pr-{number}.web.app`
+
+## File Added
+
+- **`firebase.json`** - Configuration file for Firebase Hosting that specifies:
+  - Build directory (`out`)
+  - Rewrite rules for single-page application routing
+  - Cache headers for static assets
 
 ## Next Steps
 
-1. **Choose your preferred hosting option** from the alternatives above
-2. **Set up the required secrets** for your chosen service
-3. **Replace your preview workflow** with the chosen option
+1. **Complete Firebase setup** as described above
+2. **Add the two required GitHub secrets**
+3. **Verify GitHub Pages settings** are set to "GitHub Actions"
 4. **Test with a PR** to verify preview deployment works
 5. **Monitor workflows** in the Actions tab
 
 ## Technical Details
 
 - **Production deployment:** GitHub Actions → GitHub Pages
-- **PR preview deployment:** GitHub Actions → Chosen hosting service
+- **PR preview deployment:** GitHub Actions → Firebase Hosting (preview channels)
 - **Build output:** `./out` directory from Next.js static export
 - **Permissions:** Minimal required permissions only
+- **Preview expiration:** 30 days (configurable)
 - **No gh-pages branch usage:** Completely eliminated

--- a/github-actions-deployment-setup.md
+++ b/github-actions-deployment-setup.md
@@ -13,7 +13,7 @@ Your GitHub Actions workflows have been **fully migrated to the GitHub Actions d
 - Uses `github-pages` environment
 
 ### 2. Updated PR Preview Deployment (`preview.yml`) ✅
-**Migrated from gh-pages branch to GitHub Actions + Surge.sh:**
+**Migrated from gh-pages branch to GitHub Actions + modern hosting:**
 
 **Previous Issues:**
 - Used gh-pages branch checkout and manipulation
@@ -22,35 +22,92 @@ Your GitHub Actions workflows have been **fully migrated to the GitHub Actions d
 
 **New Solution:**
 - **Uses GitHub Actions** for build and deployment process
-- **Deploys to Surge.sh** for isolated PR previews
+- **Multiple hosting options available** for isolated PR previews
 - **Eliminates gh-pages branch usage** completely
 - Uses only `contents: read` and `pull-requests: write` permissions
-- Each PR gets its own URL: `https://pr-{number}-{owner}-{repo}.surge.sh`
+- Each PR gets its own URL
 
 ### 3. Updated Cleanup (`cleanup-preview.yml`) ✅
-**Migrated from gh-pages branch to Surge.sh management:**
-- Removes Surge.sh deployments instead of gh-pages branch manipulation
-- Uses `surge teardown` command
+**Migrated from gh-pages branch to modern hosting management:**
+- Removes deployments using hosting service APIs
+- Uses minimal permissions
 - No longer requires `contents: write` permission
 
-## Required Setup
+## PR Preview Hosting Options
 
-### GitHub Pages Settings (Production)
+Choose one of these excellent alternatives:
+
+### **Option 1: Netlify** 🌟 **Most Popular**
+- **Pros:** Excellent GitHub integration, generous free tier, form handling, edge functions
+- **Cons:** Can get expensive with high traffic
+- **URL Pattern:** `https://pr-{number}--{site-name}.netlify.app`
+
+**Required Secrets:**
+- `NETLIFY_AUTH_TOKEN` - Personal access token from Netlify
+- `NETLIFY_SITE_ID` - Site ID from Netlify dashboard
+- `NETLIFY_SITE_NAME` - Your Netlify site name
+
+**Setup:**
+1. Create Netlify account and site
+2. Generate personal access token
+3. Add secrets to GitHub repository
+
+### **Option 2: Vercel** 🌟 **Best for Next.js**
+- **Pros:** Excellent Next.js optimization, edge functions, great DX
+- **Cons:** Pricing can add up, more complex for non-Next.js projects
+- **URL Pattern:** `https://pr-{number}-{repo}.vercel.app`
+
+**Required Secrets:**
+- `VERCEL_TOKEN` - Vercel API token
+- `VERCEL_ORG_ID` - Organization ID from Vercel
+- `VERCEL_PROJECT_ID` - Project ID from Vercel
+
+**Setup:**
+1. Create Vercel account and project
+2. Get API token and IDs from Vercel dashboard
+3. Add secrets to GitHub repository
+
+### **Option 3: Firebase Hosting** 🌟 **Google's Solution**
+- **Pros:** Great performance, tight Google Cloud integration, preview channels
+- **Cons:** Requires Google account, more complex setup
+- **URL Pattern:** `https://{project-id}--pr-{number}.web.app`
+
+**Required Secrets:**
+- `FIREBASE_SERVICE_ACCOUNT` - Service account JSON
+- `FIREBASE_PROJECT_ID` - Firebase project ID
+
+**Setup:**
+1. Create Firebase project
+2. Enable Hosting
+3. Create service account with Hosting Admin role
+4. Add secrets to GitHub repository
+
+### **Option 4: Cloudflare Pages** 🌟 **Fast & Global**
+- **Pros:** Excellent performance, global CDN, generous free tier
+- **Cons:** Less mature ecosystem than others
+- **URL Pattern:** `https://pr-{number}.{project}.pages.dev`
+
+**Required Secrets:**
+- `CLOUDFLARE_API_TOKEN` - API token with Pages permissions
+- `CLOUDFLARE_ACCOUNT_ID` - Account ID from Cloudflare
+- `CLOUDFLARE_PROJECT_NAME` - Pages project name
+
+**Setup:**
+1. Create Cloudflare account
+2. Create Pages project
+3. Generate API token with Pages permissions
+4. Add secrets to GitHub repository
+
+### **Option 5: Surge.sh** (Current) 💡 **Simple & Free**
+- **Pros:** Simple setup, completely free, great for small projects
+- **Cons:** Basic features, limited customization
+- **URL Pattern:** `https://pr-{number}-{owner}-{repo}.surge.sh`
+
+## Required GitHub Pages Setup (Production)
+
 1. Go to **Settings > Pages** in your GitHub repository
 2. Set **Source** to: **GitHub Actions**
 3. No branch selection needed
-
-### Surge.sh Setup (PR Previews)
-1. **Create Surge.sh account** at [surge.sh](https://surge.sh)
-2. **Get Surge token:**
-   ```bash
-   npm install -g surge
-   surge login
-   surge token
-   ```
-3. **Add GitHub secret:**
-   - Go to repository **Settings > Secrets and variables > Actions**
-   - Add new secret: `SURGE_TOKEN` with your Surge token value
 
 ## How It Works
 
@@ -61,9 +118,9 @@ Your GitHub Actions workflows have been **fully migrated to the GitHub Actions d
 
 ### PR Preview Deployments:
 1. **Build:** Uses GitHub Actions to build PR code
-2. **Deploy:** Uses GitHub Actions to deploy to Surge.sh
-3. **Result:** Each PR gets unique URL: `https://pr-{number}-{owner}-{repo}.surge.sh`
-4. **Cleanup:** Automatically removes Surge deployment when PR closes
+2. **Deploy:** Uses GitHub Actions to deploy to chosen hosting service
+3. **Result:** Each PR gets unique URL based on chosen service
+4. **Cleanup:** Automatically removes deployment when PR closes
 
 ## Benefits of This Setup
 
@@ -71,34 +128,46 @@ Your GitHub Actions workflows have been **fully migrated to the GitHub Actions d
 - ✅ **Consistent deployment approach** - GitHub Actions for everything
 - ✅ **Better security** - Minimal permissions throughout
 - ✅ **Isolated PR previews** - Each PR gets its own domain
-- ✅ **Automatic cleanup** - Surge deployments removed when PRs close
+- ✅ **Automatic cleanup** - Deployments removed when PRs close
 - ✅ **No conflicts** - PR previews don't interfere with production site
-- ✅ **Industry standard** - Surge.sh is widely used for PR previews
+- ✅ **Industry standard** - All options are widely used for PR previews
+- ✅ **Choice** - Pick the hosting service that fits your needs and budget
 
-## Why Surge.sh for PR Previews?
+## Switching Between Options
 
-GitHub Pages with GitHub Actions method is designed for single-site deployment. Using Surge.sh for PR previews allows us to:
+To switch between hosting options:
+1. **Replace** your `preview.yml` with the desired option's workflow
+2. **Update** GitHub secrets with the new service's requirements  
+3. **Update** cleanup workflow if needed
+4. **Test** with a new PR
+
+Example workflows are provided as `.example` files in your `.github/workflows/` directory.
+
+## Why These Alternatives?
+
+GitHub Pages with GitHub Actions method is designed for single-site deployment. Using these hosting services for PR previews allows us to:
 - Maintain GitHub Actions consistency
 - Avoid overwriting the production site
 - Provide isolated preview environments
-- Use a service designed for temporary deployments
+- Use services designed for temporary/preview deployments
 
 ## URLs
 
 - **Production:** Your GitHub Pages URL (e.g., `https://username.github.io/repo`)
-- **PR Previews:** `https://pr-{number}-{owner}-{repo}.surge.sh`
+- **PR Previews:** Varies by chosen hosting service (see options above)
 
 ## Next Steps
 
-1. **Set up Surge.sh token** as described above
-2. **Verify GitHub Pages settings** are set to "GitHub Actions"
-3. **Test with a PR** to verify preview deployment works
-4. **Monitor workflows** in the Actions tab
+1. **Choose your preferred hosting option** from the alternatives above
+2. **Set up the required secrets** for your chosen service
+3. **Replace your preview workflow** with the chosen option
+4. **Test with a PR** to verify preview deployment works
+5. **Monitor workflows** in the Actions tab
 
 ## Technical Details
 
 - **Production deployment:** GitHub Actions → GitHub Pages
-- **PR preview deployment:** GitHub Actions → Surge.sh
+- **PR preview deployment:** GitHub Actions → Chosen hosting service
 - **Build output:** `./out` directory from Next.js static export
 - **Permissions:** Minimal required permissions only
 - **No gh-pages branch usage:** Completely eliminated


### PR DESCRIPTION
Migrate PR preview deployments from `gh-pages` branch to Firebase Hosting to fully utilize GitHub Actions deployment method.

This change eliminates the inconsistent deployment strategy, moving all deployments to the modern GitHub Actions method. It provides isolated PR preview environments with automatic expiration and improved performance via Firebase Hosting.