### PR TITLE
Move password to secure storage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Environment Variables Configuration
+# Copy this file to .env.local and fill in your actual values
+
+# Admin password for accessing admin panel
+ADMIN_PASSWORD=your_secure_password_here
+
+# Google Maps API Key (already in use)
+NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=your_google_maps_api_key_here
+
+# Next.js configuration (already in use)
+NEXT_PUBLIC_BASE_PATH=

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ yarn-error.log*
 
 # local env files
 .env*.local
+.env
+.env.local
 
 # vercel
 .vercel

--- a/SECURITY_SETUP.md
+++ b/SECURITY_SETUP.md
@@ -1,0 +1,64 @@
+# Security Setup Guide
+
+## Password Security Implementation
+
+This application has been updated to use secure environment variables for password management instead of hardcoded values in the source code.
+
+### Setup Instructions
+
+1. **Copy the example environment file:**
+   ```bash
+   cp .env.example .env.local
+   ```
+
+2. **Update the admin password:**
+   Edit `.env.local` and replace the default password with a strong, secure password:
+   ```
+   ADMIN_PASSWORD=your_secure_password_here
+   ```
+
+3. **Important Security Notes:**
+   - The `.env.local` file is automatically ignored by Git (see `.gitignore`)
+   - Never commit passwords or secrets to version control
+   - Use a strong password with a mix of letters, numbers, and special characters
+   - Consider using a password manager to generate and store secure passwords
+
+### How It Works
+
+- **Server-side Authentication:** The password is stored and validated on the server side only
+- **API Route:** `/api/auth/login` handles authentication securely
+- **Environment Variables:** Passwords are stored in `ADMIN_PASSWORD` environment variable
+- **No Client Exposure:** The actual password never reaches the client-side code
+
+### Production Deployment
+
+For production environments:
+
+1. **Set environment variables** in your hosting platform:
+   - Vercel: Project Settings → Environment Variables
+   - Netlify: Site Settings → Environment Variables
+   - Railway: Project → Variables
+   - Other platforms: Consult their documentation
+
+2. **Use strong passwords** different from development
+
+3. **Consider additional security measures:**
+   - Rate limiting for login attempts
+   - JWT tokens for session management
+   - Two-factor authentication
+   - Regular password rotation
+
+### Development vs Production
+
+- **Development:** Use `.env.local` file (never committed)
+- **Production:** Set environment variables in your hosting platform
+- **Example:** Always keep `.env.example` updated with required variables (without actual values)
+
+### Troubleshooting
+
+If you encounter authentication issues:
+
+1. Verify `ADMIN_PASSWORD` is set in your environment
+2. Check the browser console and server logs for errors
+3. Ensure there are no extra spaces or characters in the password
+4. Restart your development server after changing environment variables

--- a/src/app/(main)/admin/page.tsx
+++ b/src/app/(main)/admin/page.tsx
@@ -18,15 +18,30 @@ export default function AdminPage() {
     }
   }, []);
 
-  const handleLogin = (e: React.FormEvent) => {
+  const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault();
     setError(''); // Clear any previous errors
     
-    if (password === 'charlie') {
-      sessionStorage.setItem('adminAuth', 'true');
-      setIsAuthenticated(true);
-    } else {
-      setError('Incorrect password. Please try again.');
+    try {
+      const response = await fetch('/api/auth/login', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ password }),
+      });
+      
+      if (response.ok) {
+        sessionStorage.setItem('adminAuth', 'true');
+        setIsAuthenticated(true);
+      } else {
+        const data = await response.json();
+        setError(data.error || 'Authentication failed. Please try again.');
+        setPassword(''); // Clear the password field
+      }
+    } catch (error) {
+      console.error('Login error:', error);
+      setError('Network error. Please try again.');
       setPassword(''); // Clear the password field
     }
   };

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(request: NextRequest) {
+  try {
+    const { password } = await request.json();
+    
+    // Get the admin password from environment variables (server-side only)
+    const adminPassword = process.env.ADMIN_PASSWORD;
+    
+    if (!adminPassword) {
+      console.error('ADMIN_PASSWORD environment variable is not set');
+      return NextResponse.json(
+        { error: 'Server configuration error' }, 
+        { status: 500 }
+      );
+    }
+    
+    if (password === adminPassword) {
+      return NextResponse.json({ success: true });
+    } else {
+      return NextResponse.json(
+        { error: 'Invalid password' }, 
+        { status: 401 }
+      );
+    }
+  } catch (error) {
+    console.error('Login error:', error);
+    return NextResponse.json(
+      { error: 'Internal server error' }, 
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Move admin password to environment variables and implement server-side authentication.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The hardcoded password in the client-side admin page was a security risk. This change moves the password to a server-side environment variable and handles authentication via a new API route, ensuring the password is never exposed to the client.